### PR TITLE
Parametrize gitea's OFFLINE_MODE as .Values.config.offlineMode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,3 +174,4 @@ The following table lists the configurable parameters of this chart and their de
 | `inPodPostgres.dataMountPath`             | Path for Postgres data storage                  | `nil`                                                         |
 | `affinity`                 | Affinity settings for pod assignment            | {}                                                         |
 | `tolerations`              | Toleration labels for pod assignment            | []                                                         
+| `config.offlineMode`              | Sets Gitea's Offline Mode. Values are `true` or `false`.           | `false`

--- a/templates/gitea/gitea-config.yaml
+++ b/templates/gitea/gitea-config.yaml
@@ -213,7 +213,7 @@ data:
     ; Indicate whether to check minimum key size with corresponding type
     MINIMUM_KEY_SIZE_CHECK = false
     ; Disable CDN even in "prod" mode
-    OFFLINE_MODE = false
+    OFFLINE_MODE = {{ .Values.config.offlineMode }}
     DISABLE_ROUTER_LOG = false
     ; Generate steps:
     ; $ ./gitea cert -ca=true -duration=8760h0m0s -host=myhost.example.com

--- a/values.yaml
+++ b/values.yaml
@@ -162,3 +162,4 @@ podAnnotations: {}
 config:
 #  secretKey: define_your_secret
   disableInstaller: false
+  offlineMode: false


### PR DESCRIPTION
Hey John/@jfelten,

I had to install gitea onto a k8s environment that is not connected to the internet. I added the `Values.config.offlineMode` parameter so that I can override `OFFLINE_MODE` in app.ini to `false`. 
Hope this becomes useful to someone.

Cheers
Firdaus
