### PR TITLE
Parameterize gitea config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,6 @@ The following table lists the configurable parameters of this chart and their de
 | `affinity`                 | Affinity settings for pod assignment            | {}                                                         |
 | `tolerations`              | Toleration labels for pod assignment            | []                                                         
 | `config.offlineMode`              | Sets Gitea's Offline Mode. Values are `true` or `false`.           | `false`
-| `config.disable_registration`     | Disable Gitea's user registration. Values are `true` or `false`.   | `false`
-| `config.require_signin`           | Require Gitea user to be signed in to see any pages. Values are `true` or `false`. | `false`
-| `config.openid_signin`            | Allow login with OpenID. Values are `true` or `false`. | `true`
+| `config.disableRegistration`     | Disable Gitea's user registration. Values are `true` or `false`.   | `false`
+| `config.requireSignin`           | Require Gitea user to be signed in to see any pages. Values are `true` or `false`. | `false`
+| `config.openidSignin`            | Allow login with OpenID. Values are `true` or `false`. | `true`

--- a/README.md
+++ b/README.md
@@ -177,4 +177,4 @@ The following table lists the configurable parameters of this chart and their de
 | `config.offlineMode`              | Sets Gitea's Offline Mode. Values are `true` or `false`.           | `false`
 | `config.disable_registration`     | Disable Gitea's user registration. Values are `true` or `false`.   | `false`
 | `config.require_signin`           | Require Gitea user to be signed in to see any pages. Values are `true` or `false`. | `false`
-| `config.enable_openid`            | Allow login with OpenID. Values are `true` or `false`. | `true`
+| `config.openid_signin`            | Allow login with OpenID. Values are `true` or `false`. | `true`

--- a/README.md
+++ b/README.md
@@ -175,3 +175,6 @@ The following table lists the configurable parameters of this chart and their de
 | `affinity`                 | Affinity settings for pod assignment            | {}                                                         |
 | `tolerations`              | Toleration labels for pod assignment            | []                                                         
 | `config.offlineMode`              | Sets Gitea's Offline Mode. Values are `true` or `false`.           | `false`
+| `config.disable_registration`     | Disable Gitea's user registration. Values are `true` or `false`.   | `false`
+| `config.require_signin`           | Require Gitea user to be signed in to see any pages. Values are `true` or `false`. | `false`
+| `config.enable_openid`            | Allow login with OpenID. Values are `true` or `false`. | `true`

--- a/templates/gitea/gitea-config.yaml
+++ b/templates/gitea/gitea-config.yaml
@@ -339,7 +339,7 @@ data:
     ;  - <username>.livejournal.com
     ;
     ; Whether to allow signin in via OpenID
-    ENABLE_OPENID_SIGNIN = {{ .Values.config.openid_signin }}
+    ENABLE_OPENID_SIGNIN = {{ .Values.config.openidSignin }}
     ; Whether to allow registering via OpenID
     ; Do not include to rely on rhw DISABLE_REGISTRATION setting
     ;ENABLE_OPENID_SIGNUP = true
@@ -365,11 +365,11 @@ data:
     ; gitea.io,example.com
     EMAIL_DOMAIN_WHITELIST=
     ; Disallow registration, only allow admins to create accounts.
-    DISABLE_REGISTRATION = {{ .Values.config.disable_registration }}
+    DISABLE_REGISTRATION = {{ .Values.config.disableRegistration }}
     ; Allow registration only using third-party services, it works only when DISABLE_REGISTRATION is false
     ALLOW_ONLY_EXTERNAL_REGISTRATION = false
     ; User must sign in to view anything.
-    REQUIRE_SIGNIN_VIEW = {{ .Values.config.require_signin }}
+    REQUIRE_SIGNIN_VIEW = {{ .Values.config.requireSignin }}
     ; Mail notification
     ENABLE_NOTIFY_MAIL = false
     ; More detail: https://github.com/gogits/gogs/issues/165

--- a/templates/gitea/gitea-config.yaml
+++ b/templates/gitea/gitea-config.yaml
@@ -339,7 +339,7 @@ data:
     ;  - <username>.livejournal.com
     ;
     ; Whether to allow signin in via OpenID
-    ENABLE_OPENID_SIGNIN = true
+    ENABLE_OPENID_SIGNIN = {{ .Values.config.openid_signin }}
     ; Whether to allow registering via OpenID
     ; Do not include to rely on rhw DISABLE_REGISTRATION setting
     ;ENABLE_OPENID_SIGNUP = true
@@ -365,11 +365,11 @@ data:
     ; gitea.io,example.com
     EMAIL_DOMAIN_WHITELIST=
     ; Disallow registration, only allow admins to create accounts.
-    DISABLE_REGISTRATION = false
+    DISABLE_REGISTRATION = {{ .Values.config.disable_registration }}
     ; Allow registration only using third-party services, it works only when DISABLE_REGISTRATION is false
     ALLOW_ONLY_EXTERNAL_REGISTRATION = false
     ; User must sign in to view anything.
-    REQUIRE_SIGNIN_VIEW = false
+    REQUIRE_SIGNIN_VIEW = {{ .Values.config.require_signin }}
     ; Mail notification
     ENABLE_NOTIFY_MAIL = false
     ; More detail: https://github.com/gogits/gogs/issues/165

--- a/values.yaml
+++ b/values.yaml
@@ -163,3 +163,7 @@ config:
 #  secretKey: define_your_secret
   disableInstaller: false
   offlineMode: false
+  require_signin: false
+  disable_registration: false
+  openid_signin: true
+

--- a/values.yaml
+++ b/values.yaml
@@ -163,7 +163,7 @@ config:
 #  secretKey: define_your_secret
   disableInstaller: false
   offlineMode: false
-  require_signin: false
-  disable_registration: false
-  openid_signin: true
+  requireSignin: false
+  disableRegistration: false
+  openidSignin: true
 


### PR DESCRIPTION
Parameterize the following Gitea config options:

`DISABLE_REGISTRATION`, `REQUIRE_SIGNIN` and `ENABLE_OPENID_SIGNIN`