### PR TITLE
Starts memcached as UID 1000

### DIFF
--- a/templates/memcached/_container.tpl
+++ b/templates/memcached/_container.tpl
@@ -28,6 +28,8 @@ Create helm partial for memcached
       port: memcache
     initialDelaySeconds: 5
     timeoutSeconds: 1
+  securityContext:
+    runAsUser: 1000
   resources:
 {{ toYaml .Values.resources.memcached | indent 10 }}
 {{- end }}


### PR DESCRIPTION
I am on the following environment:
- kubeadm-1.14.2-0.x86_64
- kubectl.x86_64 0:1.14.2-0
- kubelet.x86_64 1.14.2-0
- helm v2.13.1

When I install the chart, memcached container will fail to start with the following log:
```
can't run as root without the -u switch
```
After some digging and troubleshooting, I see that for some reason the memcached will be started as user root. Memcached binary throws the above error log when that happens. 
To fix this, I added the securityContect::runAsUser = 1000 added to the template for the memcached chart.

The container now starts normally as expected and everything works for me.

I don't know whether others face this issue but creating this PR with the fix if you think issue applies to all.
