### PR TITLE
Switch deployement apiVersion to apps/v1

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}


### PR DESCRIPTION
`apiVersion` `extensions/v1beta1` is deprecated in kubernetes, switching to `apps/v1`.

Note: a better way would be to check kubernetes version and select correct value to avoid exclusion of older kubernetes version.