### PR TITLE
SSH svc enhancements and included more configs in chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ The following table lists the configurable parameters of this chart and their de
 | `config.disableRegistration`     | Disable Gitea's user registration. Values are `true` or `false`.   | `false`
 | `config.requireSignin`           | Require Gitea user to be signed in to see any pages. Values are `true` or `false`. | `false`
 | `config.openidSignin`            | Allow login with OpenID. Values are `true` or `false`. | `true`
-| `config.notifyMail`            | Allow login with OpenID. Values are `true` or `false`. | `true`
+| `config.notifyMail`            | Mail notification. Values are `true` or `false`. | `false`
 | `config.mailer.enabled`            | Enable gitea mailer. Values are `true` or `false`. | `false`
 | `config.mailer.host`            | Hostname of the mail server. | `unset`
 | `config.mailer.port`            | Port of the mail server. Note, if the port ends with "465", SMTPS will be used. Using STARTTLS on port 587 is recommended per RFC 6409. If the server supports STARTTLS it will always be used. | `unset`

--- a/README.md
+++ b/README.md
@@ -154,6 +154,8 @@ The following table lists the configurable parameters of this chart and their de
 | `service.ssh.NodePort`            |  Manual NodePort for ssh traffic                 | `nil`                                                      |
 | `service.ssh.externalPort`           | Port exposed on the internet by a load balancer or firewall that redirects to the ingress or NodePort        | `nil`                                                      |
 | `service.ssh.externalHost`           | IP or DNS name exposed on the internet by a load balancer or firewall that redirects to the ingress or Node for http traffic                                                      |
+| `service.ssh.loadBalancerIP`           | If the service is a LoadBalancer you can pre-allocate its IP address here                                                      | `unset`
+| `service.ssh.svc_annotations`           | Set annotations for the ssh svc object. E.g. needed when using a load balancer and it should be a private load balancer instead of public.                                                      | `[]`
 | `resources.gitea.requests.memory`         | gitea container memory request                             | `100Mi`                                                      |
 | `resources.gitea.requests.cpu`      | gitea container request cpu          | `500m`                                            |
 | `resources.gitea.limits.memory`    | gitea container memory limits                      | `2Gi`                          |
@@ -183,3 +185,13 @@ The following table lists the configurable parameters of this chart and their de
 | `config.disableRegistration`     | Disable Gitea's user registration. Values are `true` or `false`.   | `false`
 | `config.requireSignin`           | Require Gitea user to be signed in to see any pages. Values are `true` or `false`. | `false`
 | `config.openidSignin`            | Allow login with OpenID. Values are `true` or `false`. | `true`
+| `config.notifyMail`            | Allow login with OpenID. Values are `true` or `false`. | `true`
+| `config.mailer.enabled`            | Enable gitea mailer. Values are `true` or `false`. | `false`
+| `config.mailer.host`            | Hostname of the mail server. | `unset`
+| `config.mailer.port`            | Port of the mail server. Note, if the port ends with "465", SMTPS will be used. Using STARTTLS on port 587 is recommended per RFC 6409. If the server supports STARTTLS it will always be used. | `unset`
+| `config.mailer.tls`            | Should SMTP connection use TLS. Values are `true` or `false`. | `false`
+| `config.mailer.from`            | Mail from address, RFC 5322. This can be just an email address, or the `"Name" <email@example.com>` format. | `unset`
+| `config.mailer.user`            | Mailer user name. | `unset`
+| `config.mailer.passwd`            | Use PASSWD = `your password` for quoting if you use special characters in the password.. | `unset`
+| `config.metrics.enabled`            | Enables metrics endpoint. Values are `true` or `false`. | `false`
+| `config.metrics.token`            | If you want to add authorization, specify a token for metrics endpoint.  | `unset`

--- a/templates/gitea/gitea-config.yaml
+++ b/templates/gitea/gitea-config.yaml
@@ -371,7 +371,7 @@ data:
     ; User must sign in to view anything.
     REQUIRE_SIGNIN_VIEW = {{ .Values.config.requireSignin }}
     ; Mail notification
-    ENABLE_NOTIFY_MAIL = false
+    ENABLE_NOTIFY_MAIL = {{ .Values.config.notifyMail }}
     ; More detail: https://github.com/gogits/gogs/issues/165
     ENABLE_REVERSE_PROXY_AUTHENTICATION = false
     ENABLE_REVERSE_PROXY_AUTO_REGISTRATION = false
@@ -418,7 +418,7 @@ data:
     PAGING_NUM = 10
 
     [mailer]
-    ENABLED = false
+    ENABLED = {{ .Values.config.mailer.enabled }}
     ; Buffer length of channel, keep it as it is if you don't know what it is.
     SEND_BUFFER_LEN = 100
     ; Name displayed in mail title
@@ -427,7 +427,7 @@ data:
     ; Gmail: smtp.gmail.com:587
     ; QQ: smtp.qq.com:465
     ; Note, if the port ends with "465", SMTPS will be used. Using STARTTLS on port 587 is recommended per RFC 6409. If the server supports STARTTLS it will always be used.
-    HOST =
+    HOST = {{ .Values.config.mailer.host }}:{{ .Values.config.mailer.port }}
     ; Disable HELO operation when hostnames are different.
     DISABLE_HELO =
     ; Custom hostname for HELO operation, if no value is provided, one is retrieved from system.
@@ -439,13 +439,13 @@ data:
     CERT_FILE = custom/mailer/cert.pem
     KEY_FILE = custom/mailer/key.pem
     ; Should SMTP connection use TLS
-    IS_TLS_ENABLED = false
+    IS_TLS_ENABLED = {{ .Values.config.mailer.tls }}
     ; Mail from address, RFC 5322. This can be just an email address, or the `"Name" <email@example.com>` format
-    FROM =
+    FROM = {{ .Values.config.mailer.from }}
     ; Mailer user name and password
-    USER =
+    USER = {{ .Values.config.mailer.user }}
     ; Use PASSWD = `your password` for quoting if you use special characters in the password.
-    PASSWD =
+    PASSWD = {{ .Values.config.mailer.passwd }}
     ; Send mails as plain text
     SEND_AS_PLAIN_TEXT = false
     ; Enable sendmail (override SMTP)
@@ -712,6 +712,6 @@ data:
 
     [metrics]
     ; Enables metrics endpoint. True or false; default is false.
-    ENABLED = false
+    ENABLED = {{ .Values.config.metrics.enabled }}
     ; If you want to add authorization, specify a token here
-    TOKEN =
+    TOKEN = {{ .Values.config.metrics.token }}

--- a/templates/gitea/gitea-ssh-svc.yaml
+++ b/templates/gitea/gitea-ssh-svc.yaml
@@ -8,7 +8,7 @@ metadata:
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
   annotations:
-  {{ toYaml .Values.service.ssh.svc_annotations | indent 4 }}
+{{ toYaml .Values.service.ssh.svc_annotations | indent 4 }}
 spec:
   type: {{ .Values.service.ssh.serviceType }}
   ports:

--- a/templates/gitea/gitea-ssh-svc.yaml
+++ b/templates/gitea/gitea-ssh-svc.yaml
@@ -7,6 +7,8 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+  {{ toYaml .Values.service.ssh.svc_annotations | indent 4 }}
 spec:
   type: {{ .Values.service.ssh.serviceType }}
   ports:

--- a/templates/gitea/gitea-ssh-svc.yaml
+++ b/templates/gitea/gitea-ssh-svc.yaml
@@ -18,6 +18,7 @@ spec:
   - name: ssh
     port: {{ .Values.service.ssh.port }}
     targetPort: ssh
+    protocol: TCP
     {{- if  .Values.service.ssh.nodePort }}
     nodePort: {{ .Values.service.ssh.nodePort }}
     {{- end }}

--- a/templates/gitea/gitea-ssh-svc.yaml
+++ b/templates/gitea/gitea-ssh-svc.yaml
@@ -11,6 +11,9 @@ metadata:
 {{ toYaml .Values.service.ssh.svc_annotations | indent 4 }}
 spec:
   type: {{ .Values.service.ssh.serviceType }}
+  {{- if (.Values.service.ssh.loadBalancerIP) and eq .Values.service.ssh.serviceType "LoadBalancer" }}
+  loadBalancerIP: {{ .Values.service.ssh.loadBalancerIP }}
+  {{- end }}
   ports:
   - name: ssh
     port: {{ .Values.service.ssh.port }}

--- a/values.yaml
+++ b/values.yaml
@@ -50,6 +50,11 @@ service:
     ## if serving on a different external port used for determining the ssh url in the gui
     #externalPort: 8022
     #externalHost: git.example.com
+    ## if serviceType is LoadBalancer
+    #loadBalancerIP: "192.168.0.100"
+    #svc_annotations:
+    #  service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    #  service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "a_subnet"
 
 ## Configure resource requests and limits
 ## ref: http://kubernetes.io/docs/user-guide/compute-resources/
@@ -166,4 +171,16 @@ config:
   requireSignin: false
   disableRegistration: false
   openidSignin: true
+  notifyMail: false
+  mailer:
+    enabled: false
+    host: smtp.gmail.com
+    port: 587
+    tls: false
+    from: ""
+    user: ""
+    passwd: ""
+  metrics:
+    enabled: false
+    token: ""
 


### PR DESCRIPTION
- [x] - I enhanced the ssh svc to support type load balancer properly (added annotations, load balancer ip, etc.)
- [x] - Added more configs for mailer and metrics sections to chart values. Set to defaults suggested in app.ini
- [x] - Updated README accordingly