### PR TITLE
Support additional freestyle configuration

### DIFF
--- a/templates/gitea/gitea-config.yaml
+++ b/templates/gitea/gitea-config.yaml
@@ -715,3 +715,7 @@ data:
     ENABLED = {{ .Values.config.metrics.enabled }}
     ; If you want to add authorization, specify a token here
     TOKEN = {{ .Values.config.metrics.token }}
+{{- if .Values.extra_config }}
+
+{{ .Values.extra_config | indent 4 }}
+{{ end }}

--- a/values.yaml
+++ b/values.yaml
@@ -185,7 +185,7 @@ config:
     token: ""
 
 ## Here you can set extra settings from https://docs.gitea.io/en-us/config-cheat-sheet/
+## The following is just an example
 # extra_config: |-
-#   [repository]
-#   ENABLE_PUSH_CREATE_USER = true
-#   ENABLE_PUSH_CREATE_ORG = true
+#   [service]
+#   ENABLE_USER_HEATMAP=false

--- a/values.yaml
+++ b/values.yaml
@@ -184,3 +184,8 @@ config:
     enabled: false
     token: ""
 
+## Here you can set extra settings from https://docs.gitea.io/en-us/config-cheat-sheet/
+# extra_config: |-
+#   [repository]
+#   ENABLE_PUSH_CREATE_USER = true
+#   ENABLE_PUSH_CREATE_ORG = true


### PR DESCRIPTION
in order to make configuration more flexible for users.

I tested this with the config I put in `values.yaml` as an example (only works in gitea v1.11.0-rc1).