### PR TITLE
Add LoadBalancerIP & SVC Annotation options to HTTP service

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ The following table lists the configurable parameters of this chart and their de
 | `service.http.NodePort`            |  Manual NodePort for web traffic                 | `nil`                                                      |
 | `service.http.externalPort`           | Port exposed on the internet by a load balancer or firewall that redirects to the ingress or NodePort        | `nil`                                                      |
 | `service.http.externalHost`           | IP or DNS name exposed on the internet by a load balancer or firewall that redirects to the ingress or Node for http traffic                       | `nil`                                                      |
+| `service.http.loadBalancerIP`           | If the service is a LoadBalancer you can pre-allocate its IP address here                                                      | `unset`
+| `service.http.svc_annotations`           | Set annotations for the http svc object.                                                       | `[]`
 | `service.ssh.serviceType`         | type of kubernetes services used for ssh i.e. ClusterIP, NodePort or LoadBalancer                | `ClusterIP`                                                 |
 | `service.ssh.port`       | http port for web traffic                               | `22`                                                      |
 | `service.ssh.NodePort`            |  Manual NodePort for ssh traffic                 | `nil`                                                      |

--- a/templates/gitea/gitea-http-svc.yaml
+++ b/templates/gitea/gitea-http-svc.yaml
@@ -7,8 +7,13 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
     release: "{{ .Release.Name }}"
     heritage: "{{ .Release.Service }}"
+  annotations:
+{{ toYaml .Values.service.http.svc_annotations | indent 4 }}
 spec:
   type: {{ .Values.service.http.serviceType }}
+  {{- if (.Values.service.http.loadBalancerIP) and eq .Values.service.http.serviceType "LoadBalancer" }}
+  loadBalancerIP: {{ .Values.service.http.loadBalancerIP }}
+  {{- end }}
   ports:
   - name: http
     port: {{ .Values.service.http.port }}

--- a/values.yaml
+++ b/values.yaml
@@ -43,6 +43,11 @@ service:
     # sometimes if is necesary to access through an external port i.e. http(s)://<dns-name>:<external-port>
     externalPort: 8280
     externalHost: git.example.com
+    ## if serviceType is LoadBalancer
+    #loadBalancerIP: "192.168.0.100"
+    #svc_annotations:
+    #  service.beta.kubernetes.io/azure-load-balancer-internal: "true"
+    #  service.beta.kubernetes.io/azure-load-balancer-internal-subnet: "a_subnet"
   ssh:
     serviceType: ClusterIP
     port: 22


### PR DESCRIPTION
Enhance HTTP svc to better support type LoadBalancer by adding LoadBalancerIP & service annotations.

Updated README and values.yaml accordingly.