### PR TITLE
Do not overwrite app.ini if it exists in PV

### DIFF
--- a/templates/init/_container.tpl
+++ b/templates/init/_container.tpl
@@ -14,9 +14,9 @@ Create helm partial for gitea server
   - name: SCRIPT
     value: &script |-
       mkdir -p /datatmp/gitea/conf
-      #if [ ! -f /datatmp/gitea/conf/app.ini ]; then
+      if [ ! -f /datatmp/gitea/conf/app.ini ]; then
         sed "s/POSTGRES_PASSWORD/${POSTGRES_PASSWORD}/g" < /etc/gitea/app.ini > /datatmp/gitea/conf/app.ini
-      #fi
+      fi
   command: ["/bin/sh",'-c', *script]
   volumeMounts:
   - name: gitea-data


### PR DESCRIPTION
Reintroduce app.ini persistence per issue #38. 

A question on how this should be implemented: Should the app.ini file be left completely alone after it is first created, or should certain values such as the postgres password (as was present previously) and other configuration options that are set in values.yaml for the app.ini file be updated as well on ```helm install``` and ```helm upgrade```? It becomes a tedious task to manually update values present in values.yaml within the app.ini file otherwise.