### PR TITLE
Correct for newer version of K8s

### DIFF
--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -2,9 +2,9 @@
 
 {{- if .Values.ingress.enabled }}
 
-  
+
   Ingress is enabled for this chart deployment.  Please access the web UI at {{ .Values.service.http.externalHost }}
-  
+
 {{- else if contains "NodePort" .Values.service.http.serviceType }}
 
   export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -21,7 +21,7 @@
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8080:80
+  kubectl port-forward $POD_NAME 8080:{{ .Values.service.http.port}}
 {{- end }}
 
 2. Connect to your Gitea ssh port:
@@ -42,5 +42,5 @@
 
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "fullname" . }}" -o jsonpath="{.items[0].metadata.name}")
   echo http://127.0.0.1:8080/
-  kubectl port-forward $POD_NAME 8022:22
+  kubectl port-forward $POD_NAME 8022:{{ .Values.service.ssh.port }}
 {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,4 +1,3 @@
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled  }}
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}ingress


### PR DESCRIPTION
Correct deployment error:

```
# helm github install --repo https://github.com/jfelten/gitea-helm-chart.git --name my-gitea -f /root/kube-tests/my-gitea.yaml
Already on 'master'
Your branch is up to date with 'origin/master'.
Already up to date.
Already on 'master'
Your branch is up to date with 'origin/master'.
/root
Installing the Helm chart from the GitHub repo
Error: validation failed: unable to recognize "": no matches for kind "Deployment" in version "extensions/v1beta1"
Error: plugin "github" exited with error
```