### PR TITLE
Fix subpath creation on the Postgre init

### DIFF
--- a/templates/init/_initPostgres.tpl
+++ b/templates/init/_initPostgres.tpl
@@ -7,7 +7,7 @@ Create helm partial for gitea server
   image: busybox:1.32.0
   imagePullPolicy: IfNotPresent
   command: ["/bin/sh"]
-  args: ["-c", "mkdir {{ .Values.inPodPostgres.dataMountPath  }}/{{ .Values.inPodPostgres.subPath  }} "]
+  args: ["-c", "if [ ! -f {{ .Values.inPodPostgres.dataMountPath  }}/{{ .Values.inPodPostgres.subPath  }} ] && [ ! -d {{ .Values.inPodPostgres.dataMountPath  }}/{{ .Values.inPodPostgres.subPath  }} ]; then mkdir {{ .Values.inPodPostgres.dataMountPath  }}/{{ .Values.inPodPostgres.subPath  }}; fi"]
   volumeMounts:
   - name: postgres-data
     mountPath: {{ .Values.inPodPostgres.dataMountPath }}

--- a/templates/init/_initPostgres.tpl
+++ b/templates/init/_initPostgres.tpl
@@ -7,7 +7,7 @@ Create helm partial for gitea server
   image: busybox:1.32.0
   imagePullPolicy: IfNotPresent
   command: ["/bin/sh"]
-  args: ["-c", "if [ ! -f {{ .Values.inPodPostgres.dataMountPath  }}/{{ .Values.inPodPostgres.subPath  }} ] && [ ! -d {{ .Values.inPodPostgres.dataMountPath  }}/{{ .Values.inPodPostgres.subPath  }} ]; then mkdir {{ .Values.inPodPostgres.dataMountPath  }}/{{ .Values.inPodPostgres.subPath  }}; fi"]
+  args: ["-c","mkdir -p {{ .Values.inPodPostgres.dataMountPath  }}/{{ .Values.inPodPostgres.subPath  }};"]
   volumeMounts:
   - name: postgres-data
     mountPath: {{ .Values.inPodPostgres.dataMountPath }}


### PR DESCRIPTION
Signed-off-by: Christophe Sauthier <christophe.sauthier@gmail.com>

If the mountpath of the subpath already contains a postgre installation, the create-sub path fails. In that case it should do nothing.