### PR TITLE
fixed port number for external postgres

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gitea
-version: 0.2.7
+version: 0.2.8
 appVersion: 1.12.4
 description: Git with a cup of tea
 icon: https://docs.gitea.io/images/gitea.png

--- a/README.md
+++ b/README.md
@@ -46,18 +46,19 @@ make build
 ```
 
 ### Database config in pod vs external db
+
 By default the chart will spin up a postgres container inside the pod. It can also work with external databases. To disable the in pod database and use and external one use the following values:
 
 ```yaml
 dbType: "postgres"
-useInPodPostgres: true
+useInPodPostgres: false
 
 #Connect to an external database
- externalDB:
-  dbUser: "postgres"
+externalDB:
+   dbUser: "postgres"
    dbPassword: "<MY_PASSWORD>"
    dbHost: "db-service-name.namespace.svc.cluster.local" # or some external host
-   dbPort: "5432"
+   dbPort: 5432
    dbDatabase: "gitea"
 ```
 
@@ -186,7 +187,7 @@ The following table lists the configurable parameters of this chart and their de
 | `externalDB.dbUser`             | external db user                  | ` unset`                                                         |
 `externalDB.dbPassword`             | external db password                  | ` unset`                                                         |
 `externalDB.dbHost`             | external db host                  | ` unset`                                                         |
-`externalDB.dbPort`             | external db port                  | ` unset`                                                         |
+`externalDB.dbPort`             | external db port - integer value (ex: 5432)            | ` unset`                                                         |
 `externalDB.dbDatabase`             | external db database name                  | ` unset`                                                         |
 | `inPodPostgres.secret` | Generated Secret to store postgres passwords   | `postgressecrets`                                                     |
 | `inPodPostgres.subPath`             | Subpath for Postgres data storage                  | `nil`                                                         |

--- a/templates/db-secret.yaml
+++ b/templates/db-secret.yaml
@@ -18,7 +18,7 @@ data:
   {{ end }}
  {{ else if .Values.externalDB }}
   dbHost: {{ .Values.externalDB.dbHost | b64enc | quote }}
-  dbPort: {{ .Values.externalDB.dbPort | b64enc | quote }}
+  dbPort: {{ printf "%d" .Values.externalDB.dbPort | b64enc | quote }}
   dbUser: {{ .Values.externalDB.dbUser | b64enc | quote }}
   dbPassword: {{ .Values.externalDB.dbPassword | b64enc | quote }}
   dbDatabase: {{ .Values.externalDB.dbDatabase | b64enc | quote }}


### PR DESCRIPTION
The helm chart would fail to install if `useInPodPostgres` is set to `false` and then properly set the `externalDB` fields. This PR fixes the issue.