### PR TITLE
Fix for bug #80 - reconfigure to store all static assets on persistent storage

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: gitea
-version: 0.2.8
+version: 0.2.9
 appVersion: 1.12.4
 description: Git with a cup of tea
 icon: https://docs.gitea.io/images/gitea.png

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 This is a kubernetes helm chart for [Gitea](https://gitea.com/).
 It deploys a pod containing containers for the Gitea application along with a Postgresql db for storing application state. It can create peristent volume claims if desired, and also an ingress if the kubernetes cluster supports it.
 
-This chart was developed and tested on kubernetes version 1.10, but should work on earlier or later versions.
+This chart should work works on all current supported versions of kubernetes. We always run it in house on the latest version to make sure the chart stays current. Currently the chart supports helm 3 only.
 
 ## Prerequisites
 
@@ -207,4 +207,3 @@ The following table lists the configurable parameters of this chart and their de
 | `config.mailer.passwd`            | Use PASSWD = `your password` for quoting if you use special characters in the password.. | `unset`
 | `config.metrics.enabled`            | Enables metrics endpoint. Values are `true` or `false`. | `false`
 | `config.metrics.token`            | If you want to add authorization, specify a token for metrics endpoint.  | `unset`
-

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 This is a kubernetes helm chart for [Gitea](https://gitea.com/).
 It deploys a pod containing containers for the Gitea application along with a Postgresql db for storing application state. It can create peristent volume claims if desired, and also an ingress if the kubernetes cluster supports it.
 
-This chart should work works on all current supported versions of kubernetes. We always run it in house on the latest version to make sure the chart stays current. Currently the chart supports helm 3 only.
+This chart should work works on current supported versions of kubernetes. It is always in active use on the latest kubernetes and sync'd to the latest gitea release to stay current.
+
+Currently the chart supports helm 3 only.
 
 ## Prerequisites
 

--- a/templates/db-secret.yaml
+++ b/templates/db-secret.yaml
@@ -18,7 +18,7 @@ data:
   {{ end }}
  {{ else if .Values.externalDB }}
   dbHost: {{ .Values.externalDB.dbHost | b64enc | quote }}
-  dbPort: {{ printf "%d" .Values.externalDB.dbPort | b64enc | quote }}
+  dbPort: {{ .Values.externalDB.dbPort | toString | b64enc | quote }}
   dbUser: {{ .Values.externalDB.dbUser | b64enc | quote }}
   dbPassword: {{ .Values.externalDB.dbPassword | b64enc | quote }}
   dbDatabase: {{ .Values.externalDB.dbDatabase | b64enc | quote }}

--- a/templates/gitea/gitea-config.yaml
+++ b/templates/gitea/gitea-config.yaml
@@ -339,7 +339,7 @@ data:
     ; KEY_FILE = https/key.pem
     ; Root directory containing templates and static files.
     ; default is the path where Gitea is executed
-    STATIC_ROOT_PATH =
+    STATIC_ROOT_PATH = /data/static
     ; Default path for App data
     APP_DATA_PATH = /data
     ; Application level GZIP support

--- a/templates/gitea/gitea-config.yaml
+++ b/templates/gitea/gitea-config.yaml
@@ -80,7 +80,7 @@ data:
     ; Whether repository file uploads are enabled. Defaults to `true`
     ENABLED = true
     ; Path for uploads. Defaults to `data/tmp/uploads` (tmp gets deleted on gitea restart)
-    TEMP_PATH = data/tmp/uploads
+    TEMP_PATH = /data/tmp/uploads
     ; One or more allowed types, e.g. image/jpeg|image/png. Nothing means any file type
     ALLOWED_TYPES =
     ; Max size of each file in megabytes. Defaults to 3MB
@@ -284,11 +284,13 @@ data:
     ; Domain name to be exposed in clone URL
     {{- if .Values.service.ssh.externalHost  }}
     SSH_DOMAIN = {{ .Values.service.ssh.externalHost  }}
+    ; The network interface the builtin SSH server should listen on
+    SSH_LISTEN_HOST = {{ .Values.service.ssh.externalHost  }}
     {{- else }}
     SSH_DOMAIN = {{ template "fullname" . }}-ssh.{{ .Release.Namespace }}.svc.cluster.local
+    ; The network interface the builtin SSH server should listen on
+    SSH_LISTEN_HOST = {{ template "fullname" . }}-ssh.{{ .Release.Namespace }}.svc.cluster.local
     {{- end }}
-    ; THe network interface the builtin SSH server should listen on
-    SSH_LISTEN_HOST =
     ; Port number to be exposed in clone URL
     {{- if .Values.service.ssh.externalPort  }}
     SSH_PORT = {{ .Values.service.ssh.externalPort  }}
@@ -339,7 +341,7 @@ data:
     ; default is the path where Gitea is executed
     STATIC_ROOT_PATH =
     ; Default path for App data
-    APP_DATA_PATH = data
+    APP_DATA_PATH = /data
     ; Application level GZIP support
     ENABLE_GZIP = false
     ; Application profiling (memory and cpu)
@@ -347,14 +349,14 @@ data:
     ; For "serve" command it dumps to disk at PPROF_DATA_PATH as (cpuprofile|memprofile)_<username>_<temporary id>
     ENABLE_PPROF = false
     ; PPROF_DATA_PATH, use an absolute path when you start gitea as service
-    PPROF_DATA_PATH = data/tmp/pprof
+    PPROF_DATA_PATH = /data/tmp/pprof
     ; Landing page, can be "home", "explore", "organizations" or "login"
     ; The "login" choice is not a security measure but just a UI flow change, use REQUIRE_SIGNIN_VIEW to force users to log in.
     LANDING_PAGE = home
     ; Enables git-lfs support. true or false, default is false.
     LFS_START_SERVER = false
     ; Where your lfs files reside, default is data/lfs.
-    LFS_CONTENT_PATH = data/lfs
+    LFS_CONTENT_PATH = /data/lfs
     ; LFS authentication secret, change this yourself
     LFS_JWT_SECRET =
     ; LFS authentication validity period (in time.Duration), pushes taking longer than this may fail.
@@ -405,7 +407,7 @@ data:
     ; NOTICE: for "utf8mb4" you must use MySQL InnoDB > 5.6. Gitea is unable to check this.
     CHARSET = utf8
     ; For "sqlite3" and "tidb", use an absolute path when you start gitea as service
-    PATH = data/gitea.db
+    PATH = /data/gitea.db
     ; For "sqlite3" only. Query timeout
     SQLITE_TIMEOUT = 500
     ; For iterate buffer, default is 50
@@ -727,7 +729,7 @@ data:
     ; file: session file path, e.g. `data/sessions`
     ; redis: network=tcp,addr=:6379,password=macaron,db=0,pool_size=100,idle_timeout=180
     ; mysql: go-sql-driver/mysql dsn config string, e.g. `root:password@/session_table`
-    PROVIDER_CONFIG = data/sessions
+    PROVIDER_CONFIG = /data/sessions
     ; Session cookie name
     COOKIE_NAME = i_like_gitea
     ; If you use session in https only, default is false
@@ -740,8 +742,8 @@ data:
     SESSION_LIFE_TIME = 86400
 
     [picture]
-    AVATAR_UPLOAD_PATH = data/avatars
-    REPOSITORY_AVATAR_UPLOAD_PATH = data/repo-avatars
+    AVATAR_UPLOAD_PATH = /data/avatars
+    REPOSITORY_AVATAR_UPLOAD_PATH = /data/repo-avatars
     ; How Gitea deals with missing repository avatars
     ; none = no avatar will be displayed; random = random avatar will be displayed; image = default image will be used
     REPOSITORY_AVATAR_FALLBACK = none
@@ -766,8 +768,8 @@ data:
     [attachment]
     ; Whether attachments are enabled. Defaults to `true`
     ENABLED = true
-    ; Path for attachments. Defaults to `data/attachments`
-    PATH = data/attachments
+    ; Path for attachments. Defaults to `/data/attachments`
+    PATH = /data/attachments
     ; One or more allowed types, e.g. "image/jpeg|image/png". Use "*/*" for all types.
     ALLOWED_TYPES = image/jpeg|image/png|application/zip|application/gzip
     ; Max size of each file. Defaults to 4MB

--- a/values.yaml
+++ b/values.yaml
@@ -40,8 +40,8 @@ service:
     port: 3000
     # nodePort: 30280
     # sometimes if is necesary to access through an external port i.e. http(s)://<dns-name>:<external-port>
-    #externalPort: 8280
-    #externalHost: git.example.com
+    # externalPort: 8280
+    # externalHost: git.example.com
     # some parts of gitea like the api use a redirect needs config if using non standard ports
     # httpAPIPort: 8280
     # if serviceType is LoadBalancer

--- a/values.yaml
+++ b/values.yaml
@@ -40,8 +40,8 @@ service:
     port: 3000
     # nodePort: 30280
     # sometimes if is necesary to access through an external port i.e. http(s)://<dns-name>:<external-port>
-    externalPort: 8280
-    externalHost: git.example.com
+    #externalPort: 8280
+    #externalHost: git.example.com
     # some parts of gitea like the api use a redirect needs config if using non standard ports
     # httpAPIPort: 8280
     # if serviceType is LoadBalancer


### PR DESCRIPTION
Fixes https://github.com/jfelten/gitea-helm-chart/issues/80. Avatar data was being stored in an ephemeral container directory and got lost on each pod restart. This PR moves anything persistent to the pods storage volume.

Note for current installations the app.ini will need to be regenerated in order for these changes to be applied

One way to do so is:

```
kubectl exec -it <ACTIVE_POD> -n <DEPLOYED_NAMESPACE> gitea --bash
cd /data//gitea/conf/app.ini
mv app.ini app.ini_old
```

the redeploy to the newer version of the chart. The installer will come up in a webpage and will regenerate the app.ini on saving.