### PR TITLE
Skip PostgreSQL init container and secret dependency when using sqlite3

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: gitea
-version: 0.2.10
-appVersion: 1.12.4
+version: 0.2.11
+appVersion: 1.13.1
 description: Git with a cup of tea
 icon: https://docs.gitea.io/images/gitea.png
 home: https://github.com/jfelten/gitea-helm-chart

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -48,3 +48,10 @@
   kubectl port-forward $POD_NAME 8022:{{ .Values.service.ssh.port }}
 
 {{- end }}
+
+3. Create an admin user:
+
+kubectl exec -it --tty -n {{ .Release.Namespace }} \
+  $(kubectl get pod -n gitea -L app=gitea-gitea -o jsonpath='{.items[*].metadata.name}') -- \
+   su git -c "gitea admin create-user --username username --password supahsecret --admin \
+   --email username@email.tld  --config /data/gitea/conf/app.ini 

--- a/templates/db-secret.yaml
+++ b/templates/db-secret.yaml
@@ -1,3 +1,4 @@
+{{- if ne .Values.dbType "sqlite3" }}
 {{- if (not .Values.inPodPostgres.existingSecret) }}
 apiVersion: v1
 kind: Secret
@@ -23,4 +24,5 @@ data:
   dbPassword: {{ .Values.externalDB.dbPassword | b64enc | quote }}
   dbDatabase: {{ .Values.externalDB.dbDatabase | b64enc | quote }}
  {{- end }}
+{{- end }}
 {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -28,8 +28,12 @@ spec:
       {{ include "gitea" . | indent 6 }}
       {{ include "memcached" . | indent 6 }}
       initContainers:
+      {{ if ne .Values.dbType "sqlite3" }}
       {{ include "init" . | indent 6 }}
       {{ include "initPostgres" . | indent 6 }}
+      {{- else }}
+      {{ include "firstrun" . | indent 6 }}
+      {{- end }}
       volumes:
       - name: gitea-data
       {{- if .Values.persistence.enabled }}

--- a/templates/gitea/_container.tpl
+++ b/templates/gitea/_container.tpl
@@ -5,12 +5,14 @@ Create helm partial for gitea server
 - name: gitea
   image: {{ .Values.images.gitea }}
   imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+  {{- if ne .Values.dbType "sqlite3"}}
   env:
   - name: POSTGRES_PASSWORD
     valueFrom:
       secretKeyRef:
         name: {{ template "db.fullname" . }}
         key: dbPassword
+  {{- end }}
   ports:
   - name: ssh
     containerPort: {{ .Values.service.ssh.port  }}

--- a/templates/gitea/gitea-config.yaml
+++ b/templates/gitea/gitea-config.yaml
@@ -20,7 +20,7 @@ data:
     ; Change it if you run locally
     RUN_USER = git
     ; Either "dev", "prod" or "test", default is "dev"
-    RUN_MODE = dev
+    RUN_MODE = prod
 
     [repository]
     ROOT =
@@ -400,6 +400,9 @@ data:
     USER = postgres
     ; Use PASSWD = `your password` for quoting if you use special characters in the password.
     PASSWD = POSTGRES_PASSWORD
+    {{ end }}
+    {{ if eq .Values.dbType "sqlite3" }}
+    DB_TYPE = sqlite3
     {{ end }}
     ; For "postgres" only, either "disable", "require" or "verify-full"
     SSL_MODE = disable

--- a/templates/init/_miigrate.tpl
+++ b/templates/init/_miigrate.tpl
@@ -1,0 +1,23 @@
+{{/*
+Create helm partial for gitea server
+*/}}
+{{- define "firstrun" }}
+- name: firstrun
+  image: {{ .Values.images.gitea }}
+  imagePullPolicy: {{ .Values.images.imagePullPolicy }}
+  env:
+  - name: SCRIPT
+    value: &script |-
+      if [ ! -f /data/gitea/conf/app.ini ]; then
+        mkdir -p /data/gitea/conf
+        cp /etc/gitea/app.ini /data/gitea/conf/app.ini
+        su git -c "mkdir -p /data/git"
+        su - git -c "/usr/local/bin/gitea migrate --config /data/gitea/conf/app.ini" | tee /data/migrate.log
+      fi
+  command: ["/bin/sh",'-c', *script]
+  volumeMounts:
+  - name: gitea-data
+    mountPath: /data
+  - name: gitea-config
+    mountPath: /etc/gitea
+{{- end }}


### PR DESCRIPTION
Hi, I've noticed that the deployment won't start when no postgresql is attached due to an empty secret (no data:)..
I've added some conditions so that it can run with sqlite for testing purposes, also added an init container to run migrations on the db on first start.

Skip PostgreSQL init container and secret dependency when using sqlite3
* added a new init script to initialize sqlite
* bumped version