### PR TITLE
Add POSTGRES_USERNAME env variable and substitution in app.ini.

### DIFF
--- a/templates/gitea/_container.tpl
+++ b/templates/gitea/_container.tpl
@@ -7,6 +7,11 @@ Create helm partial for gitea server
   imagePullPolicy: {{ .Values.images.imagePullPolicy }}
   {{- if ne .Values.dbType "sqlite3"}}
   env:
+  - name: POSTGRES_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "db.fullname" . }}
+        key: dbUser
   - name: POSTGRES_PASSWORD
     valueFrom:
       secretKeyRef:

--- a/templates/init/_container.tpl
+++ b/templates/init/_container.tpl
@@ -6,6 +6,11 @@ Create helm partial for gitea server
   image: {{ .Values.images.gitea }}
   imagePullPolicy: {{ .Values.images.imagePullPolicy }}
   env:
+  - name: POSTGRES_USERNAME
+    valueFrom:
+      secretKeyRef:
+        name: {{ template "db.fullname" . }}
+        key: dbUser
   - name: POSTGRES_PASSWORD
     valueFrom:
       secretKeyRef:
@@ -15,7 +20,7 @@ Create helm partial for gitea server
     value: &script |-
       mkdir -p /datatmp/gitea/conf
       if [ ! -f /datatmp/gitea/conf/app.ini ]; then
-        sed "s/POSTGRES_PASSWORD/${POSTGRES_PASSWORD}/g" < /etc/gitea/app.ini > /datatmp/gitea/conf/app.ini
+        sed "s/POSTGRES_PASSWORD/${POSTGRES_PASSWORD}/g; s/POSTGRES_USERNAME/${POSTGRES_USERNAME}/g" < /etc/gitea/app.ini > /datatmp/gitea/conf/app.ini
       fi
   command: ["/bin/sh",'-c', *script]
   volumeMounts:


### PR DESCRIPTION
Rather than using static database credentials, I would like to use dynamic database credentials from Hashicorp Vault. `POSTGRESQL_PASSWORD` is already being read from an environment variable; this PR reads `POSTGRESQL_USERNAME` from the environment too. The environment variable is set by reading the secret `gitea-db`.