### PR TITLE
Basic Upgrade for Ingress for newer K8S

### DIFF
--- a/templates/ingress.yaml
+++ b/templates/ingress.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.ingress.enabled  }}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "fullname" . }}ingress
@@ -17,9 +17,12 @@ spec:
     http:
       paths:
       - path: /
+        pathType: ImplementationSpecific
         backend:
-          serviceName: {{ template "fullname" . }}-http
-          servicePort: {{ .Values.service.http.port }}
+          service:
+            name: {{ template "fullname" . }}-http
+            port:
+              number: {{ .Values.service.http.port }}
   tls:
 {{ toYaml .Values.ingress.tls | indent 4 }}
 {{- end -}}


### PR DESCRIPTION
I found on newer k8s (I'm on 1.25.4) that the ingress controller could not be created as the api has changed.
I'm not sure on `pathType` so followed migration recommendation of `ImplementationSpecific`.


_(Also noted that default image tags appear out dated, but over-wrote these without issues so far)_